### PR TITLE
allow specifying pre- and post-triggers

### DIFF
--- a/document.go
+++ b/document.go
@@ -20,9 +20,11 @@ const (
 )
 
 type CreateDocumentOptions struct {
-	PartitionKeyValue string
-	IsUpsert          bool
-	IndexingDirective IndexingDirective
+	PartitionKeyValue   string
+	IsUpsert            bool
+	IndexingDirective   IndexingDirective
+	PreTriggersInclude  []string
+	PostTriggersInclude []string
 }
 
 func (ops CreateDocumentOptions) AsHeaders() (map[string]string, error) {
@@ -66,6 +68,8 @@ func (c *Client) CreateDocument(ctx context.Context, dbName, colName string,
 }
 
 type UpsertDocumentOptions struct {
+	PreTriggersInclude  []string
+	PostTriggersInclude []string
 	/* TODO */
 }
 
@@ -104,10 +108,24 @@ func (c *Client) GetDocument(ctx context.Context, dbName, colName, id string,
 	return nil
 }
 
+type ReplaceDocumentOptions struct {
+	PreTriggersInclude  []string
+	PostTriggersInclude []string
+	/* TODO */
+}
+
 // ReplaceDocument replaces a whole document.
 func (c *Client) ReplaceDocument(ctx context.Context, link string,
 	doc interface{}, ops *RequestOptions, out interface{}) error {
 	return ErrorNotImplemented
+}
+
+// DeleteDocumentOptions contains all options that can be used for deleting
+// documents.
+type DeleteDocumentOptions struct {
+	PreTriggersInclude  []string
+	PostTriggersInclude []string
+	/* TODO */
 }
 
 func (c *Client) DeleteDocument(ctx context.Context, dbName, colName, id string, ops *RequestOptions) error {

--- a/request.go
+++ b/request.go
@@ -20,9 +20,13 @@ const (
 	HEADER_IF_MATCH     = "If-Match"
 	HEADER_CHARGE       = "X-Ms-Request-Charge"
 
-	HEADER_CROSSPARTITION    = "x-ms-documentdb-query-enablecrosspartition"
-	HEADER_PARTITIONKEY      = "x-ms-documentdb-partitionkey"
-	HEADER_INDEXINGDIRECTIVE = "x-ms-indexing-directive"
+	HEADER_CROSSPARTITION       = "x-ms-documentdb-query-enablecrosspartition"
+	HEADER_PARTITIONKEY         = "x-ms-documentdb-partitionkey"
+	HEADER_INDEXINGDIRECTIVE    = "x-ms-indexing-directive"
+	HEADER_TRIGGER_PRE_INCLUDE  = "x-ms-documentdb-pre-trigger-include"
+	HEADER_TRIGGER_PRE_EXCLUDE  = "x-ms-documentdb-pre-trigger-exclude"
+	HEADER_TRIGGER_POST_INCLUDE = "x-ms-documentdb-post-trigger-include"
+	HEADER_TRIGGER_POST_EXCLUDE = "x-ms-documentdb-post-trigger-exclude"
 )
 
 type RequestOptions map[RequestOption]string


### PR DESCRIPTION
Added the options and header constants to allow specifying which
triggers should be included; both pre- and post-triggers. The -exclude
headers are added, but they are not used. Microsoft has just reserved
the headers for possible future use.