### PR TITLE
fixed unmarhsalling of provided doc

### DIFF
--- a/document.go
+++ b/document.go
@@ -294,9 +294,10 @@ func (ops QueryDocumentsOptions) AsHeaders() (map[string]string, error) {
 	return headers, nil
 }
 
-// TODO: left of here: add struct to represent query results and add as return
-// type
-func (c *Client) QueryDocuments(ctx context.Context, dbName, collName string, qry Query, doc interface{}, ops *QueryDocumentsOptions) (*QueryDocumentsResponse, error) {
+// QueryDocuments queries a collection in cosmosdb with the provided query.
+// To correctly parse the returned results you currently have to pass in
+// a slice for the returned documents, not a single document.
+func (c *Client) QueryDocuments(ctx context.Context, dbName, collName string, qry Query, docs interface{}, ops *QueryDocumentsOptions) (*QueryDocumentsResponse, error) {
 
 	headers, err := ops.AsHeaders()
 	if err != nil {
@@ -305,7 +306,9 @@ func (c *Client) QueryDocuments(ctx context.Context, dbName, collName string, qr
 
 	link := createDocsLink(dbName, collName)
 
-	results := QueryDocumentsResponse{}
+	results := QueryDocumentsResponse{
+		Documents: docs,
+	}
 
 	err = c.query(ctx, link, qry, &results, headers)
 	if err != nil {

--- a/examples/main.go
+++ b/examples/main.go
@@ -157,13 +157,18 @@ func main() {
 		},
 	}
 
-	res, err := client.QueryDocuments(context.Background(), cfg.DbName, "invoices", qry, doc, &qops)
+	var docs []ExampleDoc
+	fmt.Printf("docs: %+v\n", docs)
+	res, err := client.QueryDocuments(context.Background(), cfg.DbName, "invoices", qry, &docs, &qops)
 	if err != nil {
 		err = errors.WithStack(err)
 		fmt.Println(err)
 	}
+	//fmt.Printf("type of Documents: kind: %s", reflect.TypeOf
 
 	fmt.Printf("Query results: %+v\n", res)
+	fmt.Printf("Query results: %+v\n", res.Documents)
+	fmt.Printf("Docs after: %+v\n", docs)
 
 	// Delete a document with partition key
 	fmt.Printf("\nDelete document with partition key.\n")


### PR DESCRIPTION
* expecting `docs`, a slice of the requested document type
* accepts nil to return a `map[string]interface{}`
* also returns a `QueryDocumentsResponse` struct which includes information returned from Azure