### PR TITLE
Document create/replace/query change of signature and more headers returned

### DIFF
--- a/client.go
+++ b/client.go
@@ -62,26 +62,24 @@ func (c *Client) get(ctx context.Context, link string, ret interface{}, headers 
 	return err
 }
 
-func (c *Client) create(ctx context.Context, link string, body, ret interface{}, headers map[string]string) error {
+func (c *Client) create(ctx context.Context, link string, body, ret interface{}, headers map[string]string) (*http.Response, error) {
 	data, err := stringify(body)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	buf := bytes.NewBuffer(data)
 
-	_, err = c.method(ctx, "POST", link, ret, buf, headers)
-	return err
+	return c.method(ctx, "POST", link, ret, buf, headers)
 }
 
-func (c *Client) replace(ctx context.Context, link string, body, ret interface{}, headers map[string]string) error {
+func (c *Client) replace(ctx context.Context, link string, body, ret interface{}, headers map[string]string) (*http.Response, error) {
 	data, err := stringify(body)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	buf := bytes.NewBuffer(data)
 
-	_, err = c.method(ctx, "PUT", link, ret, buf, headers)
-	return err
+	return c.method(ctx, "PUT", link, ret, buf, headers)
 }
 
 func (c *Client) delete(ctx context.Context, link string, headers map[string]string) error {
@@ -89,7 +87,7 @@ func (c *Client) delete(ctx context.Context, link string, headers map[string]str
 	return err
 }
 
-func (c *Client) query(ctx context.Context, link string, body, ret interface{}, headers map[string]string) error {
+func (c *Client) query(ctx context.Context, link string, body, ret interface{}, headers map[string]string) (*http.Response, error) {
 	return c.create(ctx, link, body, ret, headers)
 }
 

--- a/collection.go
+++ b/collection.go
@@ -3,6 +3,7 @@ package cosmosdb
 import (
 	"context"
 	"fmt"
+
 	"github.com/pkg/errors"
 )
 
@@ -113,7 +114,7 @@ func (c *Client) CreateCollection(ctx context.Context, dbName string,
 	collection := &Collection{}
 	link := CreateCollLink(dbName, "")
 
-	err := c.create(ctx, link, colOps, collection, headers)
+	_, err := c.create(ctx, link, colOps, collection, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +157,7 @@ func (c *Client) ReplaceCollection(ctx context.Context, dbName string,
 	collection := &Collection{}
 	link := CreateCollLink(dbName, colOps.Id)
 
-	err := c.replace(ctx, link, colOps, collection, nil)
+	_, err := c.replace(ctx, link, colOps, collection, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/database.go
+++ b/database.go
@@ -23,7 +23,7 @@ func createDatabaseLink(dbName string) string {
 func (c *Client) CreateDatabase(ctx context.Context, dbName string, ops *RequestOptions) (*Database, error) {
 	db := &Database{}
 
-	err := c.create(ctx, createDatabaseLink(""), CreateDatabaseOptions{dbName}, db, nil)
+	_, err := c.create(ctx, createDatabaseLink(""), CreateDatabaseOptions{dbName}, db, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/document.go
+++ b/document.go
@@ -138,7 +138,7 @@ func (ops GetDocumentOptions) AsHeaders() (map[string]string, error) {
 }
 
 func (c *Client) GetDocument(ctx context.Context, dbName, colName, id string,
-	ops *GetDocumentOptions, out interface{}) error {
+	ops GetDocumentOptions, out interface{}) error {
 
 	headers, err := ops.AsHeaders()
 	if err != nil {

--- a/document.go
+++ b/document.go
@@ -3,6 +3,7 @@ package cosmosdb
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -34,6 +35,17 @@ type CreateDocumentOptions struct {
 	PostTriggersInclude []string
 }
 
+type DocumentResponse struct {
+	RUs          int
+	SessionToken string
+}
+
+func parseDocumentResponse(resp *http.Response) (parsed DocumentResponse) {
+	parsed.SessionToken = resp.Header.Get(HEADER_SESSION_TOKEN)
+	parsed.RUs, _ = strconv.Atoi(resp.Header.Get(HEADER_REQUEST_CHARGE))
+	return
+}
+
 func (ops CreateDocumentOptions) AsHeaders() (map[string]string, error) {
 	headers := map[string]string{}
 
@@ -59,27 +71,24 @@ func (ops CreateDocumentOptions) AsHeaders() (map[string]string, error) {
 }
 
 func (c *Client) CreateDocument(ctx context.Context, dbName, colName string,
-	doc interface{}, ops *CreateDocumentOptions) (*Resource, error) {
+	doc interface{}, ops CreateDocumentOptions) (*Resource, DocumentResponse, error) {
 
 	// add optional headers (after)
 	headers := map[string]string{}
 	var err error
-	if ops != nil {
-		headers, err = ops.AsHeaders()
-		if err != nil {
-			return nil, err
-		}
+	headers, err = ops.AsHeaders()
+	if err != nil {
+		return nil, DocumentResponse{}, err
 	}
 
 	resource := &Resource{}
 	link := createDocsLink(dbName, colName)
 
-	err = c.create(ctx, link, doc, resource, headers)
+	response, err := c.create(ctx, link, doc, resource, headers)
 	if err != nil {
-		return nil, err
+		return nil, DocumentResponse{}, err
 	}
-
-	return resource, nil
+	return resource, parseDocumentResponse(response), nil
 }
 
 type UpsertDocumentOptions struct {
@@ -182,26 +191,24 @@ func (ops ReplaceDocumentOptions) AsHeaders() (map[string]string, error) {
 
 // ReplaceDocument replaces a whole document.
 func (c *Client) ReplaceDocument(ctx context.Context, dbName, colName, id string,
-	doc interface{}, ops *ReplaceDocumentOptions) (*Resource, error) {
+	doc interface{}, ops ReplaceDocumentOptions) (*Resource, DocumentResponse, error) {
 
 	headers := map[string]string{}
 	var err error
-	if ops != nil {
-		headers, err = ops.AsHeaders()
-		if err != nil {
-			return nil, err
-		}
+	headers, err = ops.AsHeaders()
+	if err != nil {
+		return nil, DocumentResponse{}, err
 	}
 
 	link := createDocLink(dbName, colName, id)
 	resource := &Resource{}
 
-	err = c.replace(ctx, link, doc, resource, headers)
+	response, err := c.replace(ctx, link, doc, resource, headers)
 	if err != nil {
-		return nil, err
+		return nil, DocumentResponse{}, err
 	}
 
-	return resource, nil
+	return resource, parseDocumentResponse(response), nil
 }
 
 // DeleteDocumentOptions contains all options that can be used for deleting
@@ -232,7 +239,7 @@ func (ops DeleteDocumentOptions) AsHeaders() (map[string]string, error) {
 	return headers, nil
 }
 
-func (c *Client) DeleteDocument(ctx context.Context, dbName, colName, id string, ops *DeleteDocumentOptions) error {
+func (c *Client) DeleteDocument(ctx context.Context, dbName, colName, id string, ops DeleteDocumentOptions) error {
 	headers, err := ops.AsHeaders()
 	if err != nil {
 		return err
@@ -297,11 +304,11 @@ func (ops QueryDocumentsOptions) AsHeaders() (map[string]string, error) {
 // QueryDocuments queries a collection in cosmosdb with the provided query.
 // To correctly parse the returned results you currently have to pass in
 // a slice for the returned documents, not a single document.
-func (c *Client) QueryDocuments(ctx context.Context, dbName, collName string, qry Query, docs interface{}, ops *QueryDocumentsOptions) (*QueryDocumentsResponse, error) {
+func (c *Client) QueryDocuments(ctx context.Context, dbName, collName string, qry Query, docs interface{}, ops QueryDocumentsOptions) (QueryDocumentsResponse, error) {
 
 	headers, err := ops.AsHeaders()
 	if err != nil {
-		return nil, err
+		return QueryDocumentsResponse{}, err
 	}
 
 	link := createDocsLink(dbName, collName)
@@ -310,10 +317,12 @@ func (c *Client) QueryDocuments(ctx context.Context, dbName, collName string, qr
 		Documents: docs,
 	}
 
-	err = c.query(ctx, link, qry, &results, headers)
+	response, err := c.query(ctx, link, qry, &results, headers)
 	if err != nil {
-		return nil, err
+		return QueryDocumentsResponse{}, err
 	}
+	results.RUs, _ = strconv.Atoi(response.Header.Get(HEADER_REQUEST_CHARGE))
+	results.Continuation = response.Header.Get(HEADER_CONTINUATION)
 
-	return &results, nil
+	return results, nil
 }

--- a/offer.go
+++ b/offer.go
@@ -36,11 +36,9 @@ type OfferReplaceOptions struct {
 	Rid              string                 `json:"_rid"`
 }
 
-
 func createOfferLink(offerId string) string {
 	return "offers/" + offerId
 }
-
 
 // https://docs.microsoft.com/en-us/rest/api/cosmos-db/get-an-offer
 func (c *Client) GetOffer(ctx context.Context, offerId string, ops *RequestOptions) (*Offer, error) {
@@ -73,7 +71,7 @@ func (c *Client) ReplaceOffer(ctx context.Context, offerOps OfferReplaceOptions,
 	offer := &Offer{}
 	link := createOfferLink(offerOps.Rid)
 
-	err := c.replace(ctx, link, offerOps, offer, nil)
+	_, err := c.replace(ctx, link, offerOps, offer, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/query.go
+++ b/query.go
@@ -13,8 +13,10 @@ type QueryParam struct {
 
 // TODO: add missing fields
 type QueryDocumentsResponse struct {
-	Documents interface{}
-	Count     int `json:"_count"`
+	Documents    interface{}
+	Count        int `json:"_count"`
+	Continuation string
+	RUs          int
 }
 
 // NewQuery create a query with given parameters.

--- a/request.go
+++ b/request.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	// Request headers
 	HEADER_XDATE             = "X-Ms-Date"
 	HEADER_AUTH              = "Authorization"
 	HEADER_VER               = "X-Ms-Version"
@@ -16,12 +17,10 @@ const (
 	HEADER_CONLEN            = "Content-Length"
 	HEADER_IS_QUERY          = "x-ms-documentdb-isquery"
 	HEADER_UPSERT            = "x-Ms-Documentdb-Is-Upsert"
-	HEADER_CONTINUATION      = "X-Ms-Continuation"
 	HEADER_IF_MATCH          = "If-Match"
 	HEADER_IF_NONE_MATCH     = "If-None-Match"
 	HEADER_CHARGE            = "X-Ms-Request-Charge"
 	HEADER_CONSISTENCY_LEVEL = "x-ms-consistency-level"
-	HEADER_SESSION_TOKEN     = "x-ms-session-token"
 	HEADER_OFFER_THROUGHPUT  = "x-ms-offer-throughput"
 	HEADER_OFFER_TYPE        = "x-ms-offer-type"
 
@@ -32,6 +31,13 @@ const (
 	HEADER_TRIGGER_PRE_EXCLUDE  = "x-ms-documentdb-pre-trigger-exclude"
 	HEADER_TRIGGER_POST_INCLUDE = "x-ms-documentdb-post-trigger-include"
 	HEADER_TRIGGER_POST_EXCLUDE = "x-ms-documentdb-post-trigger-exclude"
+
+	// Both request and response
+	HEADER_SESSION_TOKEN = "x-ms-session-token"
+	HEADER_CONTINUATION  = "x-ms-continuation"
+
+	// Response headers
+	HEADER_REQUEST_CHARGE = "x-ms-request-charge"
 )
 
 type RequestOptions map[RequestOption]string

--- a/trigger.go
+++ b/trigger.go
@@ -54,7 +54,7 @@ func (c *Client) CreateTrigger(ctx context.Context, dbName string, colName strin
 	trigger := &Trigger{}
 	link := CreateTriggerLink(dbName, colName, "")
 
-	err := c.create(ctx, link, trigOps, trigger, nil)
+	_, err := c.create(ctx, link, trigOps, trigger, nil)
 
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (c *Client) ReplaceTrigger(ctx context.Context, dbName, colName string,
 	trigger := &Trigger{}
 	link := CreateTriggerLink(dbName, colName, trigOps.Id)
 
-	err := c.replace(ctx, link, trigOps, trigger, nil)
+	_, err := c.replace(ctx, link, trigOps, trigger, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Feel free to comment but wait with merging until this has been tested against real cosmos / emulator.

Changes to most Document methods:

* Returning session token and RUs for create/replace, and RUs and continuation for Query
* Change type of small structs in signatures from pass-by-pointer to pass-by-value as using a pointer in this context serves no purpose (compiler probably optimizes it away but it is also more verbose so...).