### PR TITLE
Add logging

### DIFF
--- a/cmd/cosmosdb-apply/main.go
+++ b/cmd/cosmosdb-apply/main.go
@@ -110,7 +110,7 @@ func newCosmosDbClient(masterKey string) *cosmosapi.Client {
 	cosmosCfg := cosmosapi.Config{
 		MasterKey: masterKey,
 	}
-	client := cosmosapi.New(fmt.Sprintf("https://%s.documents.azure.com:443", options.instanceName), cosmosCfg, nil)
+	client := cosmosapi.New(fmt.Sprintf("https://%s.documents.azure.com:443", options.instanceName), cosmosCfg, nil, nil)
 	return client
 }
 

--- a/cosmosapi/client.go
+++ b/cosmosapi/client.go
@@ -168,10 +168,8 @@ func (c *Client) do(ctx context.Context, r *http.Request, data interface{}) (*ht
 	}
 
 	var resp *http.Response
-	var err error
 	for retryCount := 0; retryCount <= c.Config.MaxRetries; retryCount++ {
-		resp = nil
-		err = nil
+		var err error
 		if retryCount > 0 {
 			delay := backoffDelay(retryCount)
 			t := time.NewTimer(delay)
@@ -190,14 +188,12 @@ func (c *Client) do(ctx context.Context, r *http.Request, data interface{}) (*ht
 			return nil, err
 		}
 		err = c.handleResponse(ctx, r, resp, data)
-		if err != errRetry {
-			break
+		if err == errRetry {
+			continue
 		}
+		return resp, err
 	}
-	if err == errRetry {
-		err = errUnexpectedHTTPStatus
-	}
-	return resp, err
+	return resp, ErrMaxRetriesExceeded
 }
 
 

--- a/cosmosapi/client.go
+++ b/cosmosapi/client.go
@@ -6,19 +6,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/vippsas/go-cosmosdb/logging"
 )
-
-func init() {
-	// Using standard log lib to avoid external dependencies for now.
-	// TODO: Consider if debug is neccesary
-	log.SetOutput(ioutil.Discard)
-}
 
 var (
 	// TODO: useful?
@@ -39,11 +33,14 @@ type Client struct {
 	Url    string
 	Config Config
 	Client *http.Client
+	Log    logging.ExtendedLogger
 }
 
 // New makes a new client to communicate to a cosmosdb instance.
 // If no http.Client is provided it defaults to the http.DefaultClient
-func New(url string, cfg Config, cl *http.Client) *Client {
+// The log argument can either be an StdLogger (log.Logger), an ExtendedLogger (like logrus.Logger)
+// or nil (logging disabled)
+func New(url string, cfg Config, cl *http.Client, log logging.StdLogger) *Client {
 	client := &Client{
 		Url:    strings.Trim(url, "/"),
 		Config: cfg,
@@ -53,6 +50,8 @@ func New(url string, cfg Config, cl *http.Client) *Client {
 	if client.Client == nil {
 		client.Client = http.DefaultClient
 	}
+
+	client.Log = logging.Adapt(log)
 
 	return client
 }
@@ -94,15 +93,15 @@ func (c *Client) query(ctx context.Context, link string, body, ret interface{}, 
 func (c *Client) method(ctx context.Context, method, link string, ret interface{}, body io.Reader, headers map[string]string) (*http.Response, error) {
 	req, err := http.NewRequest(method, path(c.Url, link), body)
 	if err != nil {
-		log.Println(err)
+		c.Log.Errorln(err)
 		return nil, err
 	}
-	log.Printf("Will call: %s\n", req.URL)
+	c.Log.Debug("Will call: %s\n", req.URL)
 	//r := ResourceRequest(link, req)
 
 	defaultHeaders, err := defaultHeaders(method, link, c.Config.MasterKey)
 	if err != nil {
-		log.Println(err)
+		c.Log.Debug(err)
 		return nil, err
 	}
 
@@ -118,7 +117,7 @@ func (c *Client) method(ctx context.Context, method, link string, ret interface{
 		req.Header.Add(k, v)
 	}
 
-	log.Printf("Headers: %s\n", req.Header)
+	c.Log.Debug("Headers: %s\n", req.Header)
 
 	return c.do(ctx, req, ret)
 }
@@ -180,7 +179,7 @@ func (c *Client) do(ctx context.Context, r *http.Request, data interface{}) (*ht
 	retryCount := 0
 	for {
 		r.Body = ioutil.NopCloser(bytes.NewReader(b))
-		log.Printf("Executing request\n")
+		c.Log.Debug("Executing request")
 		resp, err := cli.Do(r)
 		if err != nil {
 			return nil, err
@@ -197,6 +196,10 @@ func (c *Client) do(ctx context.Context, r *http.Request, data interface{}) (*ht
 		defer resp.Body.Close()
 
 		if err != nil {
+			b, err2 := ioutil.ReadAll(resp.Body)
+			if err2 == nil {
+				c.Log.Errorln("Error response from Cosmos DB: " + string(b))
+			}
 			return resp, err
 		}
 

--- a/cosmosapi/client_test.go
+++ b/cosmosapi/client_test.go
@@ -24,7 +24,7 @@ func TestOne(t *testing.T) {
 	cfg := Config{
 		MasterKey: TestKey,
 	}
-	c := New(ts.URL, cfg, nil)
+	c := New(ts.URL, cfg, nil, nil)
 
 	_, err := c.GetDatabase(context.Background(), "ToDoList", nil)
 	assert.NotNil(t, err)

--- a/cosmosapi/errors.go
+++ b/cosmosapi/errors.go
@@ -15,6 +15,7 @@ var (
 	errRetry                 = errors.New("retry")
 	ErrorNotImplemented      = errors.New("not implemented")
 	ErrWrongQueryContentType = errors.New("Wrong content type. Must be " + QUERY_CONTENT_TYPE)
+	ErrMaxRetriesExceeded	 = errors.New("Max retries exceeded")
 
 	// Map http codes to cosmos errors messages
 	// Description taken directly from https://docs.microsoft.com/en-us/rest/api/cosmos-db/http-status-codes-for-cosmosdb

--- a/cosmostest/cosmostest.go
+++ b/cosmostest/cosmostest.go
@@ -74,7 +74,7 @@ func RawClient(cfg Config) *cosmosapi.Client {
 	return cosmosapi.New(cfg.Uri, cosmosapi.Config{
 		MasterKey:  cfg.MasterKey,
 		MaxRetries: 3,
-	}, httpClient)
+	}, httpClient, nil)
 }
 
 func Teardown(c cosmos.Collection) {

--- a/examples/cosmosapi/main.go
+++ b/examples/cosmosapi/main.go
@@ -45,7 +45,7 @@ func main() {
 		MasterKey: cfg.DbKey,
 	}
 
-	client := cosmosapi.New(cfg.DbUrl, cosmosCfg, nil)
+	client := cosmosapi.New(cfg.DbUrl, cosmosCfg, nil, nil)
 
 	// Get a database
 	db, err := client.GetDatabase(context.Background(), cfg.DbName, nil)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,129 @@
+package logging
+
+import (
+	"io/ioutil"
+	"log"
+)
+
+// This interface matches the print methods of the logger in the standard log library
+type StdLogger interface {
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+}
+
+// The ExtendedLogger interface matches the print methods with various severity levels provided by the loggers in
+// the logrus library
+type ExtendedLogger interface {
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Print(args ...interface{})
+	Warn(args ...interface{})
+	Warning(args ...interface{})
+	Error(args ...interface{})
+
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Printf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+
+	Debugln(args ...interface{})
+	Infoln(args ...interface{})
+	Println(args ...interface{})
+	Warnln(args ...interface{})
+	Warningln(args ...interface{})
+	Errorln(args ...interface{})
+}
+
+// Adapt a logger implementing the StdLogger interface to the ExtendedLogger by delegating all method implementations
+// to one of Print(), Printf() or Println().
+// This allows us to support extended logging functionality without having to explicitly depend on a specific
+// library such as logrus.
+// If the logger argument is nil, a logger writing to io.Discard will be returned.
+func Adapt(logger StdLogger) ExtendedLogger {
+	if logger == nil {
+		return &stdToExtendedLoggerAdapter{log.New(ioutil.Discard, "", 0)}
+	}
+	if extLogger, ok := logger.(ExtendedLogger); ok {
+		return extLogger
+	}
+	return &stdToExtendedLoggerAdapter{StdLogger: logger}
+}
+
+type stdToExtendedLoggerAdapter struct {
+	StdLogger
+}
+
+func (a *stdToExtendedLoggerAdapter) Debug(args ...interface{}) {
+	a.StdLogger.Print(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Info(args ...interface{}) {
+	a.StdLogger.Print(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Print(args ...interface{}) {
+	a.StdLogger.Print(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Warn(args ...interface{}) {
+	a.StdLogger.Print(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Warning(args ...interface{}) {
+	a.StdLogger.Print(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Error(args ...interface{}) {
+	a.StdLogger.Print(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Debugf(format string, args ...interface{}) {
+	a.StdLogger.Printf(format, args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Infof(format string, args ...interface{}) {
+	a.StdLogger.Printf(format, args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Printf(format string, args ...interface{}) {
+	a.StdLogger.Printf(format, args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Warnf(format string, args ...interface{}) {
+	a.StdLogger.Printf(format, args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Warningf(format string, args ...interface{}) {
+	a.StdLogger.Printf(format, args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Errorf(format string, args ...interface{}) {
+	a.StdLogger.Printf(format, args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Debugln(args ...interface{}) {
+	a.StdLogger.Println(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Infoln(args ...interface{}) {
+	a.StdLogger.Println(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Println(args ...interface{}) {
+	a.StdLogger.Println(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Warnln(args ...interface{}) {
+	a.StdLogger.Println(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Warningln(args ...interface{}) {
+	a.StdLogger.Println(args...)
+}
+
+func (a *stdToExtendedLoggerAdapter) Errorln(args ...interface{}) {
+	a.StdLogger.Println(args...)
+}


### PR DESCRIPTION
Logger is passed as an argument to the cosmosapi.New() constructor.
The client supports logging with the standard lib logger or the logrus
logger or anything that implements the same interface

Also refactored the retry loop in `cosmosapi.Client.do()` to avoid potential memory leaks due to `defer` inside of a for-loop and added an error for max retries exceeded