### PR TITLE
wrapped NewV4 call with Must

### DIFF
--- a/cosmostest/cosmostest.go
+++ b/cosmostest/cosmostest.go
@@ -88,7 +88,7 @@ func Teardown(c cosmos.Collection) {
 func SetupCollection(log cosmos.Logger, cfg Config, collectionId, partitionKey string) cosmos.Collection {
 	prefix := cfg.CollectionIdPrefix
 	if prefix == "" {
-		prefix = uuid.NewV4().String() + "-"
+		prefix = uuid.Must(uuid.NewV4()).String() + "-"
 	}
 
 	collectionId = prefix + collectionId


### PR DESCRIPTION
gofrs NewV4 method has a multi-value return and must be wrapped with `Must`