### PR TITLE
Change type of PartitionKey from string to interface{}

### DIFF
--- a/cosmos/cosmos_test.go
+++ b/cosmos/cosmos_test.go
@@ -43,7 +43,7 @@ type mockCosmos struct {
 	ReturnSession   string
 	ReturnError     error
 	GotId           string
-	GotPartitionKey string
+	GotPartitionKey interface{}
 	GotMethod       string
 	GotUpsert       bool
 	GotX            int
@@ -138,7 +138,6 @@ func (mock *mockCosmosNotFound) DeleteCollection(ctx context.Context, dbName, co
 func (mock *mockCosmosNotFound) DeleteDatabase(ctx context.Context, dbName string, ops *cosmosapi.RequestOptions) error {
 	panic("implement me")
 }
-
 
 //
 // Tests

--- a/cosmos/transaction.go
+++ b/cosmos/transaction.go
@@ -97,7 +97,7 @@ func (txn *Transaction) commit() error {
 
 }
 
-func (txn *Transaction) Get(partitionValue, id string, target interface{}) (err error) {
+func (txn *Transaction) Get(partitionValue interface{}, id string, target interface{}) (err error) {
 
 	if txn.fetchedId != "" && txn.fetchedId != id {
 		return errors.Wrap(NotImplementedError, "Fetching one than one entity in transaction not supported yet")

--- a/cosmosapi/document.go
+++ b/cosmosapi/document.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"encoding/json"
 )
 
 // Document
@@ -26,7 +25,6 @@ const (
 	ConsistencyLevelSession  = ConsistencyLevel("Session")
 	ConsistencyLevelEventual = ConsistencyLevel("Eventual")
 )
-
 
 type CreateDocumentOptions struct {
 	PartitionKeyValue   interface{}
@@ -51,11 +49,11 @@ func (ops CreateDocumentOptions) AsHeaders() (map[string]string, error) {
 	headers := map[string]string{}
 
 	if ops.PartitionKeyValue != nil {
-		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		v, err := MarshalPartitionKeyHeader(ops.PartitionKeyValue)
 		if err != nil {
 			return nil, err
 		}
-		headers[HEADER_PARTITIONKEY] = string(v)
+		headers[HEADER_PARTITIONKEY] = v
 	}
 
 	headers[HEADER_UPSERT] = strconv.FormatBool(ops.IsUpsert)
@@ -128,11 +126,11 @@ func (ops GetDocumentOptions) AsHeaders() (map[string]string, error) {
 	headers[HEADER_IF_NONE_MATCH] = strconv.FormatBool(ops.IfNoneMatch)
 
 	if ops.PartitionKeyValue != nil {
-		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		v, err := MarshalPartitionKeyHeader(ops.PartitionKeyValue)
 		if err != nil {
 			return nil, err
 		}
-		headers[HEADER_PARTITIONKEY] = string(v)
+		headers[HEADER_PARTITIONKEY] = v
 	}
 
 	if ops.ConsistencyLevel != "" {
@@ -176,11 +174,11 @@ func (ops ReplaceDocumentOptions) AsHeaders() (map[string]string, error) {
 	headers := map[string]string{}
 
 	if ops.PartitionKeyValue != nil {
-		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		v, err := MarshalPartitionKeyHeader(ops.PartitionKeyValue)
 		if err != nil {
 			return nil, err
 		}
-		headers[HEADER_PARTITIONKEY] = string(v)
+		headers[HEADER_PARTITIONKEY] = v
 	}
 
 	if ops.IndexingDirective != "" {
@@ -238,11 +236,11 @@ func (ops DeleteDocumentOptions) AsHeaders() (map[string]string, error) {
 
 	//TODO: DRY
 	if ops.PartitionKeyValue != nil {
-		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		v, err := MarshalPartitionKeyHeader(ops.PartitionKeyValue)
 		if err != nil {
 			return nil, err
 		}
-		headers[HEADER_PARTITIONKEY] = string(v)
+		headers[HEADER_PARTITIONKEY] = v
 	}
 
 	if ops.PreTriggersInclude != nil && len(ops.PreTriggersInclude) > 0 {
@@ -302,11 +300,11 @@ func (ops QueryDocumentsOptions) AsHeaders() (map[string]string, error) {
 
 	//TODO: DRY
 	if ops.PartitionKeyValue != nil {
-		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		v, err := MarshalPartitionKeyHeader(ops.PartitionKeyValue)
 		if err != nil {
 			return nil, err
 		}
-		headers[HEADER_PARTITIONKEY] = string(v)
+		headers[HEADER_PARTITIONKEY] = v
 	}
 
 	headers[HEADER_IS_QUERY] = strconv.FormatBool(ops.IsQuery)

--- a/cosmosapi/document.go
+++ b/cosmosapi/document.go
@@ -2,10 +2,10 @@ package cosmosapi
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+	"encoding/json"
 )
 
 // Document
@@ -27,8 +27,9 @@ const (
 	ConsistencyLevelEventual = ConsistencyLevel("Eventual")
 )
 
+
 type CreateDocumentOptions struct {
-	PartitionKeyValue   string
+	PartitionKeyValue   interface{}
 	IsUpsert            bool
 	IndexingDirective   IndexingDirective
 	PreTriggersInclude  []string
@@ -49,8 +50,12 @@ func parseDocumentResponse(resp *http.Response) (parsed DocumentResponse) {
 func (ops CreateDocumentOptions) AsHeaders() (map[string]string, error) {
 	headers := map[string]string{}
 
-	if ops.PartitionKeyValue != "" {
-		headers[HEADER_PARTITIONKEY] = fmt.Sprintf("[\"%s\"]", ops.PartitionKeyValue)
+	if ops.PartitionKeyValue != nil {
+		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		if err != nil {
+			return nil, err
+		}
+		headers[HEADER_PARTITIONKEY] = string(v)
 	}
 
 	headers[HEADER_UPSERT] = strconv.FormatBool(ops.IsUpsert)
@@ -112,7 +117,7 @@ func (c *Client) ListDocument(ctx context.Context, link string,
 
 type GetDocumentOptions struct {
 	IfNoneMatch       bool
-	PartitionKeyValue string
+	PartitionKeyValue interface{}
 	ConsistencyLevel  ConsistencyLevel
 	SessionToken      string
 }
@@ -122,8 +127,12 @@ func (ops GetDocumentOptions) AsHeaders() (map[string]string, error) {
 
 	headers[HEADER_IF_NONE_MATCH] = strconv.FormatBool(ops.IfNoneMatch)
 
-	if ops.PartitionKeyValue != "" {
-		headers[HEADER_PARTITIONKEY] = fmt.Sprintf("[\"%s\"]", ops.PartitionKeyValue)
+	if ops.PartitionKeyValue != nil {
+		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		if err != nil {
+			return nil, err
+		}
+		headers[HEADER_PARTITIONKEY] = string(v)
 	}
 
 	if ops.ConsistencyLevel != "" {
@@ -156,7 +165,7 @@ func (c *Client) GetDocument(ctx context.Context, dbName, colName, id string,
 }
 
 type ReplaceDocumentOptions struct {
-	PartitionKeyValue   string
+	PartitionKeyValue   interface{}
 	IndexingDirective   IndexingDirective
 	PreTriggersInclude  []string
 	PostTriggersInclude []string
@@ -166,8 +175,12 @@ type ReplaceDocumentOptions struct {
 func (ops ReplaceDocumentOptions) AsHeaders() (map[string]string, error) {
 	headers := map[string]string{}
 
-	if ops.PartitionKeyValue != "" {
-		headers[HEADER_PARTITIONKEY] = fmt.Sprintf("[\"%s\"]", ops.PartitionKeyValue)
+	if ops.PartitionKeyValue != nil {
+		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		if err != nil {
+			return nil, err
+		}
+		headers[HEADER_PARTITIONKEY] = string(v)
 	}
 
 	if ops.IndexingDirective != "" {
@@ -214,7 +227,7 @@ func (c *Client) ReplaceDocument(ctx context.Context, dbName, colName, id string
 // DeleteDocumentOptions contains all options that can be used for deleting
 // documents.
 type DeleteDocumentOptions struct {
-	PartitionKeyValue   string
+	PartitionKeyValue   interface{}
 	PreTriggersInclude  []string
 	PostTriggersInclude []string
 	/* TODO */
@@ -224,8 +237,12 @@ func (ops DeleteDocumentOptions) AsHeaders() (map[string]string, error) {
 	headers := map[string]string{}
 
 	//TODO: DRY
-	if ops.PartitionKeyValue != "" {
-		headers[HEADER_PARTITIONKEY] = fmt.Sprintf("[\"%s\"]", ops.PartitionKeyValue)
+	if ops.PartitionKeyValue != nil {
+		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		if err != nil {
+			return nil, err
+		}
+		headers[HEADER_PARTITIONKEY] = string(v)
 	}
 
 	if ops.PreTriggersInclude != nil && len(ops.PreTriggersInclude) > 0 {
@@ -258,7 +275,7 @@ func (c *Client) DeleteDocument(ctx context.Context, dbName, colName, id string,
 // QueryDocumentsOptions bundles all options supported by Cosmos DB when
 // querying for documents.
 type QueryDocumentsOptions struct {
-	PartitionKeyValue    string
+	PartitionKeyValue    interface{}
 	IsQuery              bool
 	ContentType          string
 	MaxItemCount         int
@@ -284,8 +301,12 @@ func (ops QueryDocumentsOptions) AsHeaders() (map[string]string, error) {
 	headers := map[string]string{}
 
 	//TODO: DRY
-	if ops.PartitionKeyValue != "" {
-		headers[HEADER_PARTITIONKEY] = fmt.Sprintf("[\"%s\"]", ops.PartitionKeyValue)
+	if ops.PartitionKeyValue != nil {
+		v, err := json.Marshal([]interface{}{ops.PartitionKeyValue})
+		if err != nil {
+			return nil, err
+		}
+		headers[HEADER_PARTITIONKEY] = string(v)
 	}
 
 	headers[HEADER_IS_QUERY] = strconv.FormatBool(ops.IsQuery)

--- a/cosmosapi/errors.go
+++ b/cosmosapi/errors.go
@@ -12,10 +12,11 @@ const (
 )
 
 var (
-	errRetry                 = errors.New("retry")
-	ErrorNotImplemented      = errors.New("not implemented")
-	ErrWrongQueryContentType = errors.New("Wrong content type. Must be " + QUERY_CONTENT_TYPE)
-	ErrMaxRetriesExceeded	 = errors.New("Max retries exceeded")
+	errRetry                   = errors.New("retry")
+	ErrorNotImplemented        = errors.New("not implemented")
+	ErrWrongQueryContentType   = errors.New("Wrong content type. Must be " + QUERY_CONTENT_TYPE)
+	ErrMaxRetriesExceeded      = errors.New("Max retries exceeded")
+	ErrInvalidPartitionKeyType = errors.New("Partition key type must be a simple type (nil, string, int, float, etc.)")
 
 	// Map http codes to cosmos errors messages
 	// Description taken directly from https://docs.microsoft.com/en-us/rest/api/cosmos-db/http-status-codes-for-cosmosdb

--- a/cosmosapi/utils.go
+++ b/cosmosapi/utils.go
@@ -1,0 +1,19 @@
+package cosmosapi
+
+import (
+	"encoding/json"
+)
+
+func MarshalPartitionKeyHeader(partitionKeyValue interface{}) (string, error) {
+	switch partitionKeyValue.(type) {
+	// for now we disallow float, as using floats as keys is conceptually flawed (floats are not exact values)
+	case nil, string, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+	default:
+		return "", ErrInvalidPartitionKeyType
+	}
+	res, err := json.Marshal([]interface{}{partitionKeyValue})
+	if err != nil {
+		return "", err
+	}
+	return string(res), nil
+}

--- a/cosmosapi/utils_test.go
+++ b/cosmosapi/utils_test.go
@@ -1,0 +1,27 @@
+package cosmosapi
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMarshalPartitionKeyHeader(t *testing.T) {
+	checkMarshal := func(in, expect interface{}) {
+		v, err := MarshalPartitionKeyHeader(in)
+		if _, ok := expect.(error); ok {
+			require.Equal(t, expect, err)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, expect, v)
+		}
+	}
+
+	checkMarshal(nil, `[null]`)
+	checkMarshal("foo", `["foo"]`)
+	checkMarshal(1, `[1]`)
+	checkMarshal(int32(1), `[1]`)
+	checkMarshal(17179869184, `[17179869184]`) // in > 2^32
+
+	checkMarshal(1234.0, ErrInvalidPartitionKeyType)
+	checkMarshal(struct{}{}, ErrInvalidPartitionKeyType)
+}


### PR DESCRIPTION
The type of a partition key can be anything that will serialize to a
simple JSON type