### PR TITLE
Sprocs: interface{} type for partitionKey in highlevel client

### DIFF
--- a/cosmos/collection.go
+++ b/cosmos/collection.go
@@ -181,7 +181,7 @@ func (c Collection) Query(query string, entities interface{}) error {
 }
 
 // Execute a StoredProcedure on the collection
-func (c Collection) ExecuteSproc(sprocName string,  partitionKeyValue string, ret interface{}, args... interface{}) error {
+func (c Collection) ExecuteSproc(sprocName string, partitionKeyValue interface{}, ret interface{}, args ...interface{}) error {
 	opts := cosmosapi.ExecuteStoredProcedureOptions{PartitionKeyValue: partitionKeyValue}
 	return c.Client.ExecuteStoredProcedure(
 		c.GetContext(), c.DbName, c.Name, sprocName, opts, ret, args...)


### PR DESCRIPTION
Collection.ExecuteStoredProcedure() now takes partitionKeyValue as
interface{} instead of string