### PR TITLE
Use unique key instead of document ID in transaction

### DIFF
--- a/cosmos/cosmos_test.go
+++ b/cosmos/cosmos_test.go
@@ -247,7 +247,7 @@ func TestTransactionCacheHappyDay(t *testing.T) {
 		s := struct {
 			Etag string `json:"_etag"`
 		}{}
-		key, err := cacheKey("partitionvalue", "idvalue")
+		key, err := newUniqueKey("partitionvalue", "idvalue")
 		require.NoError(t, err)
 		json.Unmarshal([]byte(session.state.entityCache[key]), &s)
 		require.Equal(t, expect, s.Etag)

--- a/cosmos/unique_key.go
+++ b/cosmos/unique_key.go
@@ -1,0 +1,21 @@
+package cosmos
+
+import (
+	"encoding/json"
+	"github.com/pkg/errors"
+)
+
+// In Cosmos DB document IDs are only unique within a partition key value. For cases where we need a globally unique
+// identifier, such as caching, `uniqueKey` can be used.
+// Documents also have the _rid property which is also globally unique, but not always practical to use as it requires
+// fetching an existing document.
+type uniqueKey string
+
+func newUniqueKey(partitionKeyValue interface{}, id string) (uniqueKey, error) {
+	// Use JSON for the cache key to match how Cosmos represents values
+	d, err := json.Marshal([]interface{}{partitionKeyValue, id})
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return uniqueKey(d), nil
+}


### PR DESCRIPTION
The transaction tracking of fetched document used document ID instead of
a globally unique identifier (similarily to the recent session cache problem).
Here we create a uniqueKey type, computed from the
partitionKeyValue/docId combination, to use as the identifier in both
transaction tracking and session cache.