### PR TITLE
Add continuation token for partition key ranges

### DIFF
--- a/cosmosapi/get_partition_key_ranges.go
+++ b/cosmosapi/get_partition_key_ranges.go
@@ -2,6 +2,10 @@ package cosmosapi
 
 import (
 	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 func (c *Client) GetPartitionKeyRanges(
@@ -11,16 +15,22 @@ func (c *Client) GetPartitionKeyRanges(
 ) (response GetPartitionKeyRangesResponse, err error) {
 	link := CreateCollLink(databaseName, collectionName) + "/pkranges"
 	var responseBody getPartitionKeyRangesResponseBody
-	if headers, err := options.AsHeaders(); err != nil {
-		return response, err
-	} else if _, err := c.get(ctx, link, &responseBody, headers); err != nil {
-		return response, err
-	} else {
-		response.PartitionKeyRanges = responseBody.PartitionKeyRanges
-		response.Id = responseBody.Id
-		response.Rid = responseBody.Rid
+	headers, err := options.AsHeaders()
+	if err != nil {
 		return response, err
 	}
+	httpResponse, err := c.get(ctx, link, &responseBody, headers)
+	if err != nil {
+		return response, err
+	}
+	response.PartitionKeyRanges = responseBody.PartitionKeyRanges
+	response.Id = responseBody.Id
+	response.Rid = responseBody.Rid
+	err = response.parseHeaders(httpResponse)
+	if err != nil {
+		return response, errors.WithMessage(err, "Failed to get partition key ranges")
+	}
+	return response, err
 }
 
 type getPartitionKeyRangesResponseBody struct {
@@ -37,10 +47,18 @@ type PartitionKeyRange struct {
 }
 
 type GetPartitionKeyRangesOptions struct {
+	MaxItemCount int
+	Continuation string
 }
 
 func (ops GetPartitionKeyRangesOptions) AsHeaders() (map[string]string, error) {
 	headers := map[string]string{}
+	if ops.MaxItemCount != 0 {
+		headers[HEADER_MAX_ITEM_COUNT] = strconv.Itoa(ops.MaxItemCount)
+	}
+	if ops.Continuation != "" {
+		headers[HEADER_CONTINUATION] = ops.Continuation
+	}
 	return headers, nil
 }
 
@@ -48,4 +66,22 @@ type GetPartitionKeyRangesResponse struct {
 	Id                 string
 	Rid                string
 	PartitionKeyRanges []PartitionKeyRange
+	RequestCharge      float64
+	SessionToken       string
+	Continuation       string
+	Etag               string
+}
+
+func (r *GetPartitionKeyRangesResponse) parseHeaders(httpResponse *http.Response) error {
+	r.SessionToken = httpResponse.Header.Get(HEADER_SESSION_TOKEN)
+	r.Continuation = httpResponse.Header.Get(HEADER_CONTINUATION)
+	r.Etag = httpResponse.Header.Get(HEADER_ETAG)
+	if _, ok := httpResponse.Header[HEADER_REQUEST_CHARGE]; ok {
+		requestCharge, err := strconv.ParseFloat(httpResponse.Header.Get(HEADER_REQUEST_CHARGE), 64)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		r.RequestCharge = requestCharge
+	}
+	return nil
 }

--- a/cosmosapi/list_collections.go
+++ b/cosmosapi/list_collections.go
@@ -2,9 +2,10 @@ package cosmosapi
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"net/http"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 type ListCollectionsOptions struct {
@@ -61,11 +62,11 @@ func (r ListCollectionsResponse) parse(httpResponse *http.Response) (ListCollect
 	r.Continuation = httpResponse.Header.Get(HEADER_CONTINUATION)
 	r.Etag = httpResponse.Header.Get(HEADER_ETAG)
 	if _, ok := httpResponse.Header[HEADER_REQUEST_CHARGE]; ok {
-		if requestCharge, err := strconv.ParseFloat(httpResponse.Header.Get(HEADER_REQUEST_CHARGE), 64); err != nil {
+		requestCharge, err := strconv.ParseFloat(httpResponse.Header.Get(HEADER_REQUEST_CHARGE), 64)
+		if err != nil {
 			return r, errors.WithStack(err)
-		} else {
-			r.RequestCharge = requestCharge
 		}
+		r.RequestCharge = requestCharge
 	}
 	return r, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/stretchr/testify v1.2.2
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gofrs/uuid v3.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
The current implementation of `GetPartitionKeyRanges` does not support continuation tokens. This is bad news if you have collections with more than 100 partitions, so I added support for it, along with a utility paginator mechanism (very similar to aws-sdk-go's way of doing it).

As the previous version of `GetPartitionKeyRanges` does not indicate that it may only return a partial response, I also made it fetch all partition keys if the `MaxItemCount` and `Continuation` values are unset, to prevent sudden unexpected results for users of this library.