### PR TITLE
Ensure HTTP client reads the entire body

### DIFF
--- a/cosmosapi/client.go
+++ b/cosmosapi/client.go
@@ -228,5 +228,9 @@ func (c Client) handleResponse(ctx context.Context, req *http.Request, resp *htt
 	if resp.ContentLength == 0 {
 		return nil
 	}
-	return readJson(resp.Body, ret)
+	err = readJson(resp.Body, ret)
+	// even if JSON parsing failed, we still want to consume all bytes from Body
+	// in order to reuse the connection.
+	io.Copy(ioutil.Discard, resp.Body)
+	return err
 }


### PR DESCRIPTION
According to https://godoc.org/net/http#Client.Do, the http.Transport may be unable to reuse the connection if not EOF is returned from Body, and Close is not called on it. Assuming the JSON decoder will not readmore than it has to, this will never happen. This commit ensures that we trigger EOF by copying the remaining bytes (whitespace, if any) to /dev/null before returning the result.